### PR TITLE
Fixed production endpoint for rating and Ship service

### DIFF
--- a/fedex/wsdl/RateService_v16.wsdl
+++ b/fedex/wsdl/RateService_v16.wsdl
@@ -4860,7 +4860,7 @@
   </binding>
   <service name="RateService">
     <port name="RateServicePort" binding="ns:RateServiceSoapBinding">
-      <s1:address location="https://wsbeta.fedex.com:443/web-services/rate"/>
+      <s1:address location="https://ws.fedex.com:443/web-services/rate"/>
     </port>
   </service>
 </definitions>

--- a/fedex/wsdl/ShipService_v13.wsdl
+++ b/fedex/wsdl/ShipService_v13.wsdl
@@ -6284,7 +6284,7 @@
   </binding>
   <service name="ShipService">
     <port name="ShipServicePort" binding="ns:ShipServiceSoapBinding">
-      <s1:address location="https://wsbeta.fedex.com:443/web-services/ship"/>
+      <s1:address location="https://ws.fedex.com:443/web-services/ship"/>
     </port>
   </service>
 </definitions>


### PR DESCRIPTION
Hi, I just changed the WSDL for pointing on production server.  We tracked that problem when using production settings instead of testing.

Thanks for all.